### PR TITLE
descript x-ray and ct preprocessing in readme and change util

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ We provide 4 well-known CNN models (ResNet, VGG, DenseNet, EfficientNet) and eac
 
 ​	i. Chest X-rays
 
-		Chest X-rays Prepreocessing is divided with two methods.
+	Chest X-rays Prepreocessing is divided with two methods.
 
-		1. min-max scaling : First, load dicom image. Then change it to pixel array and change data type to float32. Second, If dicom image has 3 channel, change it to 1 channel and array to (image_size,image_size) by using squeeze(). Then resize image size you want. Third, execute min-max scaling with bits of dicom image.
-		It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+	1. min-max scaling : First, load dicom image. Then change it to pixel array and change data type to float32. Second, If dicom image has 3 channel, change it to 1 channel and array to (image_size,image_size) by using squeeze(). Then resize image size you want. Third, execute min-max scaling with bits of dicom image.
+	It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
 
-		2. percentile : The previous two preprocessing processes of percentile are the same as those of min-max scaling. And execute percentile to reduce intensity of L,R mark. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+	2. percentile : The previous two preprocessing processes of percentile are the same as those of min-max scaling. And execute percentile to reduce intensity of L,R mark. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
 
-		Note that X-ray dicom image has 8,12,16 bits.
+	Note that X-ray dicom image has 8,12,16 bits.
 
 ​	ii. CT slices
 
-		The previous two preprocessing precesses of CT slices are the same as those of Chest X-rays. And CT image has Rescale Intercept and Rescale Slope. Rescale Slope is multiplied and then Rescale Intercept is added to CT image array. It is mandantory preprocess task. Third, execute min-max scaling with bits of dicom image. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+	The previous two preprocessing precesses of CT slices are the same as those of Chest X-rays. And CT image has Rescale Intercept and Rescale Slope. Rescale Slope is multiplied and then Rescale Intercept is added to CT image array. It is mandantory preprocess task. Third, execute min-max scaling with bits of dicom image. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
 
-		Note that CT slices dicom image has 8,12,16 bits.
+	Note that CT slices dicom image has 8,12,16 bits.
 
 ​	iii. MR slices
 

--- a/README.md
+++ b/README.md
@@ -57,17 +57,21 @@ We provide 4 well-known CNN models (ResNet, VGG, DenseNet, EfficientNet) and eac
 ### 4. Supporting Modalities
 
 ​	i. Chest X-rays
+
 		Chest X-rays Prepreocessing is divided with two methods.
 
-		- min-max scaling : First, load dicom image. Then change it to pixel array and change data type to float32. Second, If dicom image has 3 channel, change it to 1 channel and array to (image_size,image_size) by using squeeze(). Then resize image size you want. Third, execute min-max scaling with bits of dicom image.
+		1. min-max scaling : First, load dicom image. Then change it to pixel array and change data type to float32. Second, If dicom image has 3 channel, change it to 1 channel and array to (image_size,image_size) by using squeeze(). Then resize image size you want. Third, execute min-max scaling with bits of dicom image.
 		It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
 
-		- percentile : The previous two preprocessing processes of percentile are the same as those of min-max scaling. And execute percentile to reduce intensity of L,R mark. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+		2. percentile : The previous two preprocessing processes of percentile are the same as those of min-max scaling. And execute percentile to reduce intensity of L,R mark. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
 
-		Note that dicom image has 8,12,16 bits.
+		Note that X-ray dicom image has 8,12,16 bits.
 
 ​	ii. CT slices
+
 		The previous two preprocessing precesses of CT slices are the same as those of Chest X-rays. And CT image has Rescale Intercept and Rescale Slope. Rescale Slope is multiplied and then Rescale Intercept is added to CT image array. It is mandantory preprocess task. Third, execute min-max scaling with bits of dicom image. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+
+		Note that CT slices dicom image has 8,12,16 bits.
 
 ​	iii. MR slices
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,17 @@ We provide 4 well-known CNN models (ResNet, VGG, DenseNet, EfficientNet) and eac
 ### 4. Supporting Modalities
 
 ​	i. Chest X-rays
+		Chest X-rays Prepreocessing is divided with two methods.
+
+		- min-max scaling : First, load dicom image. Then change it to pixel array and change data type to float32. Second, If dicom image has 3 channel, change it to 1 channel and array to (image_size,image_size) by using squeeze(). Then resize image size you want. Third, execute min-max scaling with bits of dicom image.
+		It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+
+		- percentile : The previous two preprocessing processes of percentile are the same as those of min-max scaling. And execute percentile to reduce intensity of L,R mark. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
+
+		Note that dicom image has 8,12,16 bits.
 
 ​	ii. CT slices
+		The previous two preprocessing precesses of CT slices are the same as those of Chest X-rays. And CT image has Rescale Intercept and Rescale Slope. Rescale Slope is multiplied and then Rescale Intercept is added to CT image array. It is mandantory preprocess task. Third, execute min-max scaling with bits of dicom image. It is normalized from 0 to 1. If pixel value is over 1 or under 0, it must be changed to 1 or 0. Finally, check PhotometricInterpretation of dicom image. If it is MONOCHROME1, change it to MONOCHROME2.
 
 ​	iii. MR slices
 

--- a/util.py
+++ b/util.py
@@ -64,7 +64,8 @@ def CT_preprocess(data, image_size, window_width=None, window_level=None): # (in
 
         pixel_array_image = (pixel_array_image - image_min) / (image_max - image_min)
 
-    # If dicom image has MONOCHROME1, image is converted.
+    # If dicom image has MONOCHROME1, min value of image is white pixel, while max value of image is black pixel
+    # In other words, it is conversion version of image that we know conventionally. So it has to be converted
     if dicom_image.PhotometricInterpretation == 'MONOCHROME1':
         pixel_array_image = 1.0 - pixel_array_image
 
@@ -88,7 +89,8 @@ def Xray_preprocess_minmax(data, image_size):
 
     pixel_array_image = (pixel_array_image - np.min(pixel_array_image)) / (np.max(pixel_array_image) - np.min(pixel_array_image))
 
-    # If dicom image has MONOCHROME1, min value of image is white pixel. So it has to be converted.
+    # If dicom image has MONOCHROME1, min value of image is white pixel, while max value of image is black pixel
+    # In other words, it is conversion version of image that we know conventionally. So it has to be converted
     if dicom_image.PhotometricInterpretation == 'MONOCHROME1':
         pixel_array_image = 1.0 - pixel_array_image
 
@@ -111,17 +113,11 @@ def Xray_preprocess_percentile(data, image_size):
         pixel_array_image = cv2.resize(pixel_array_image, (image_size, image_size))
 
     # pixel value is divided by Percentile 99% and normalized from 0 to 1
-    pixel_array_image -= np.min(pixel_array_image) # Start pixel value from 0
+    pixel_array_image = (pixel_array_image - np.min(pixel_array_image)) / (np.max(pixel_array_image) - np.min(pixel_array_image))
     pixel_array_image /= np.percentile(pixel_array_image, 99)
 
-    image_min = 0.0
-    image_max = 1.0
-
-    # If image pixel is over max value or under min value, threshold to max and min
-    pixel_array_image[np.where(pixel_array_image < image_min)] = image_min
-    pixel_array_image[np.where(pixel_array_image > image_max)] = image_max
-
-    # If dicom image has MONOCHROME1, min value of image is white pixel. So it has to be converted.
+    # If dicom image has MONOCHROME1, min value of image is white pixel, while max value of image is black pixel
+    # In other words, it is conversion version of image that we know conventionally. So it has to be converted
     if dicom_image.PhotometricInterpretation == 'MONOCHROME1':
         pixel_array_image = 1.0 - pixel_array_image
 

--- a/util.py
+++ b/util.py
@@ -47,14 +47,12 @@ def CT_preprocess(data, image_size):
 
     pixel_array_image = (pixel_array_image - np.min(pixel_array_image)) / (2.0**dicom_image.BitsStored-1.0) # CT image has 8, 12, 16bits. It must be normalized.
 
-    image_min = np.min(pixel_array_image)
-    image_max = np.max(pixel_array_image)
+    image_min = 0.0
+    image_max = 1.0
 
     # If image pixel is over max value or under min value, threshold to max and min
     pixel_array_image[np.where(pixel_array_image < image_min)] = image_min
     pixel_array_image[np.where(pixel_array_image > image_max)] = image_max
-
-    pixel_array_image = (pixel_array_image-image_min) / (image_max-image_min) # Normalize from 0 to 1
 
     # If dicom image has MONOCHROME1, image is converted.
     if dicom_image.PhotometricInterpretation == 'MONOCHROME1':
@@ -80,14 +78,16 @@ def Xray_preprocess_minmax(data, image_size):
 
     pixel_array_image = (pixel_array_image - np.min(pixel_array_image)) / (2.0**dicom_image.BitsStored-1.0) # X-ray image has 8, 12, 16bits. It must be normalized.
 
-    image_min = np.min(pixel_array_image)
-    image_max = np.max(pixel_array_image)
+    image_min = 0.0
+    image_max = 1.0
 
     # If image pixel is over max value or under min value, threshold to max and min
     pixel_array_image[np.where(pixel_array_image < image_min)] = image_min
     pixel_array_image[np.where(pixel_array_image > image_max)] = image_max
 
-    pixel_array_image = (pixel_array_image-image_min) / (image_max-image_min) # Normalize from 0 to 1
+    # If dicom image has MONOCHROME1, image is converted.
+    if dicom_image.PhotometricInterpretation == 'MONOCHROME1':
+        pixel_array_image = 1.0 - pixel_array_image
 
     return pixel_array_image # output : 0.0 ~ 1.0
 
@@ -112,8 +112,15 @@ def Xray_preprocess_percentile(data, image_size):
     pixel_array_image -= np.min(pixel_array_image) # Start pixel value from 0
     pixel_array_image /= np.percentile(pixel_array_image, 99) # Normalize from 0 to 1
 
-    # If image pixel is over 1.0 or under 0.0, threshold to 1.0 and 0.0
-    pixel_array_image[np.where(pixel_array_image < 0.0)] = 0.0
-    pixel_array_image[np.where(pixel_array_image > 1.0)] = 1.0
+    image_min = 0.0
+    image_max = 1.0
+
+    # If image pixel is over max value or under min value, threshold to max and min
+    pixel_array_image[np.where(pixel_array_image < image_min)] = image_min
+    pixel_array_image[np.where(pixel_array_image > image_max)] = image_max
+
+    # If dicom image has MONOCHROME1, image is converted.
+    if dicom_image.PhotometricInterpretation == 'MONOCHROME1':
+        pixel_array_image = 1.0 - pixel_array_image
 
     return pixel_array_image # output : 0.0 ~ 1.0


### PR DESCRIPTION
1. X-ray와 CT slices 전처리 과정 readme에 작성했습니다.
2. util에서 X-ray의 min-max scaling과 percentile 전처리 함수에 MONOCHROME 관련 전처리 추가 했습니다.
3. X-ray와 CT slices 전처리 함수 전부에 0~1로 먼저 normalize 시키고 그 다음에 pixel 값이 1을 넘거나 0을 못 넘는 값들에 대해 threshold를 시켰습니다.